### PR TITLE
abcv6 4.1+ fixes, better model normals

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -92,4 +92,4 @@ def unregister():
     bpy.types.TOPBAR_MT_file_import.remove(converter.ConvertPS2LTBToLTA.menu_func_import)
     
     # Helpers
-    vertex_normals.uregister()
+    vertex_normals.unregister()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -26,6 +26,7 @@ if 'bpy' in locals():
     if 'importer'           in locals(): importlib.reload(importer)
     if 'exporter'           in locals(): importlib.reload(exporter)
     if 'converter'          in locals(): importlib.reload(converter)
+    if 'vertex_normals'     in locals(): importlib.reload(vertex_normals)
 
 import bpy
 from . import hash_ps2
@@ -40,6 +41,7 @@ from . import writer_lta_pc
 from . import importer
 from . import exporter
 from . import converter
+from . import vertex_normals
 
 
 from bpy.utils import register_class, unregister_class
@@ -68,6 +70,9 @@ def register():
     # Converters
     bpy.types.TOPBAR_MT_file_import.append(converter.ConvertPCLTBToLTA.menu_func_import)
     bpy.types.TOPBAR_MT_file_import.append(converter.ConvertPS2LTBToLTA.menu_func_import)
+    
+    # Helpers
+    vertex_normals.register()
 
 
 def unregister():
@@ -85,3 +90,6 @@ def unregister():
     # Converters
     bpy.types.TOPBAR_MT_file_import.remove(converter.ConvertPCLTBToLTA.menu_func_import)
     bpy.types.TOPBAR_MT_file_import.remove(converter.ConvertPS2LTBToLTA.menu_func_import)
+    
+    # Helpers
+    vertex_normals.uregister()

--- a/src/builder.py
+++ b/src/builder.py
@@ -81,7 +81,14 @@ class ModelBuilder(object):
                 bone_indices[bone] = i
 
             ''' Vertices '''
-            for (vertex_index, vertex) in enumerate(mesh.vertices):
+            corner_normals = [loop.normal for loop in mesh.loops]
+            mesh.normals_split_custom_set(corner_normals)
+            mesh.update()
+
+            # Access the loop normals
+            loop_normals = [loop.normal for loop in mesh.loops]
+
+            for vertex_index, vertex in enumerate(mesh.vertices):
                 weights = []
                 for vertex_group in mesh_object.vertex_groups:
 
@@ -102,13 +109,20 @@ class ModelBuilder(object):
                     except RuntimeError:
                         pass
 
-
                 # Note: This corrects any rotation done on import
                 rot = Matrix.Rotation(radians(-180), 4, 'Z') @ Matrix.Rotation(radians(90), 4, 'X')
 
                 v = Vertex()
                 v.location = vertex.co @ rot
-                v.normal = vertex.normal
+
+                # Replace vertex.normal with the average loop normal for this vertex
+                vertex_loop_normals = [
+                    loop_normals[loop_index]
+                    for loop_index in range(len(mesh.loops))
+                    if mesh.loops[loop_index].vertex_index == vertex_index
+                ]
+                v.normal = sum(vertex_loop_normals, Vector()) / len(vertex_loop_normals) if vertex_loop_normals else vertex.normal
+
                 v.weights.extend(weights)
                 lod.vertices.append(v)
 
@@ -263,7 +277,7 @@ class ModelBuilder(object):
                 scaled_time = time * (1.0 / get_framerate())
 
                 subframe_time = time - floor(time)
-                bpy.context.scene.frame_set(time, subframe = subframe_time)
+                bpy.context.scene.frame_set(int(time), subframe = subframe_time)
 
                 keyframe = Animation.Keyframe()
                 keyframe.time = scaled_time
@@ -300,7 +314,7 @@ class ModelBuilder(object):
                     scaled_time = time * (1.0 / get_framerate())
 
                     subframe_time = time - floor(time)
-                    bpy.context.scene.frame_set(time, subframe = subframe_time)
+                    bpy.context.scene.frame_set(int(time), subframe = subframe_time)
 
                     transform = Animation.Keyframe.Transform()
 

--- a/src/reader_abc_v6_pc.py
+++ b/src/reader_abc_v6_pc.py
@@ -58,10 +58,17 @@ class ABCV6ModelReader(object):
 
         vertex_normal_chars = unpack('3b', f)
 
-        vertex.normal.x = vertex_normal_chars[0]
-        vertex.normal.y = vertex_normal_chars[1]
-        vertex.normal.z = vertex_normal_chars[2]
+        vertex.normal.x = (vertex_normal_chars[0] / 127.0)
+        vertex.normal.y = (vertex_normal_chars[1] / 127.0)
+        vertex.normal.z = (vertex_normal_chars[2] / 127.0)
+        
+        # Convert to mathutils.Vector for easier normalization
+        normal_vector = vertex.normal
 
+        # Normalize the normal using mathutils
+        vertex.normal = normal_vector.normalized()
+        print("Read normal:", vertex.normal.x * 127, vertex.normal.y * 127, vertex.normal.z * 127)
+        
         weight = Weight()
 
         # It seems "pieces" are split by node index..
@@ -79,13 +86,13 @@ class ABCV6ModelReader(object):
     def _read_face_vertex(self, f):
         face_vertex_list = [FaceVertex(), FaceVertex(), FaceVertex()]
 
-        face_vertex_list[0].texcoord.xy = unpack('2f', f)
-        face_vertex_list[1].texcoord.xy = unpack('2f', f)
         face_vertex_list[2].texcoord.xy = unpack('2f', f)
+        face_vertex_list[1].texcoord.xy = unpack('2f', f)
+        face_vertex_list[0].texcoord.xy = unpack('2f', f)
 
-        face_vertex_list[0].vertex_index = unpack('H', f)[0]
-        face_vertex_list[1].vertex_index = unpack('H', f)[0]
         face_vertex_list[2].vertex_index = unpack('H', f)[0]
+        face_vertex_list[1].vertex_index = unpack('H', f)[0]
+        face_vertex_list[0].vertex_index = unpack('H', f)[0]
 
         # Jake: Not needed?
         face_normal = unpack('3b', f)
@@ -124,6 +131,7 @@ class ABCV6ModelReader(object):
 
             lod.faces = copy.deepcopy(main_lod.faces)
             lod.vertices = [self._read_vertex(f) for _ in range(count)]
+            lod.normals = [vertex.normal for vertex in lod.vertices]
 
             lod_list.append(lod)
         # End For
@@ -325,6 +333,8 @@ class ABCV6ModelReader(object):
                     self._model.flip_anim = flip_anim
         # End
 
+        '''OLD bind matrix stuff, this was breaking normal. Fix later maybe?
+        
         # Okay we're going to use the first animation's location and rotation data for our node's bind_matrix
         for node_index in range(len(self._model.nodes)):
             node = self._model.nodes[node_index]
@@ -349,7 +359,7 @@ class ABCV6ModelReader(object):
             # Apply it!
             node.bind_matrix = parent_matrix @ mat
             node.inverse_bind_matrix = node.bind_matrix.inverted()
-        # End
+        # End'''
 
         # Ok now we're going to apply out mesh offset
         vert_index = 0
@@ -371,7 +381,7 @@ class ABCV6ModelReader(object):
                 vert.location = self._model.nodes[node_index].bind_matrix @ vert.location
             # End
 
-            vert.normal = self._model.nodes[node_index].bind_matrix @ vert.normal
+            #vert.normal = self._model.nodes[node_index].bind_matrix @ vert.normal
             vert_index += 1
         # End
 

--- a/src/vertex_normals.py
+++ b/src/vertex_normals.py
@@ -1,0 +1,92 @@
+import bpy
+import mathutils
+
+def build_model_vertex_normals(obj):
+    # Ensure we are working with a mesh
+    if obj.type != 'MESH':
+        print("Object is not a mesh")
+        return
+
+    # Ensure the mesh is updated
+    bpy.context.view_layer.objects.active = obj
+    bpy.ops.object.mode_set(mode='OBJECT')
+    mesh = obj.data
+
+    # Create a list to store the new vertex normals
+    new_normals = [mathutils.Vector((0, 0, 0)) for _ in range(len(mesh.vertices))]
+
+    # Create adjacency information (similar to the C++ VertPolyAdjacency structure)
+    adjacency = {i: [] for i in range(len(mesh.vertices))}
+    
+    # Loop through faces (triangles) and update adjacency list
+    for face in mesh.polygons:
+        v1, v2, v3 = face.vertices
+        normal = face.normal
+
+        # Add this face to the adjacency list for each of its vertices
+        adjacency[v1].append(normal)
+        adjacency[v2].append(normal)
+        adjacency[v3].append(normal)
+
+    # Now calculate the vertex normals
+    for i, adj_tris in adjacency.items():
+        if len(adj_tris) == 0:  # Prevent division by zero
+            continue  # Skip if no adjacent faces (unlikely in most meshes)
+
+        normal_sum = mathutils.Vector((0, 0, 0))
+
+        for tri_normal in adj_tris:
+            normal_sum += tri_normal
+
+        # Average the normals
+        normal_sum /= len(adj_tris)
+
+        # Normalize the resulting normal
+        new_normals[i] = normal_sum.normalized()
+
+        # Print the vertex normal for debugging
+        print("New normal:", new_normals[i].x * 127, new_normals[i].y * 127, new_normals[i].z * 127)
+
+    # Set custom normals to vertices
+    mesh.normals_split_custom_set_from_vertices(new_normals)
+    obj.data.update()
+
+class LITHTECHPanel(bpy.types.Panel):
+    """Creates a Panel in the LITHTECH category"""
+    bl_label = "LITHTECH Helpers"
+    bl_idname = "OBJECT_PT_vertex_normals"
+    bl_space_type = 'VIEW_3D'
+    bl_region_type = 'UI'
+    bl_category = 'LITHTECH'  # Custom panel category
+
+    def draw(self, context):
+        layout = self.layout
+
+        # Add a button to the panel
+        layout.operator("object.build_vertex_normals_operator", text="Generate Vertex Normals")
+
+
+class BuildVertexNormalsOperator(bpy.types.Operator):
+    """Set vertex normals with same weighting as Lithtech ModelEdit"""
+    bl_idname = "object.build_vertex_normals_operator"
+    bl_label = "Generate Vertex Normals"
+    
+    def execute(self, context):
+        obj = bpy.context.active_object
+        if obj:
+            build_model_vertex_normals(obj)
+        return {'FINISHED'}
+
+
+def register():
+    bpy.utils.register_class(LITHTECHPanel)
+    bpy.utils.register_class(BuildVertexNormalsOperator)
+
+
+def unregister():
+    bpy.utils.unregister_class(LITHTECHPanel)
+    bpy.utils.unregister_class(BuildVertexNormalsOperator)
+
+
+if __name__ == "__main__":
+    register()

--- a/src/writer_abc_v6_pc.py
+++ b/src/writer_abc_v6_pc.py
@@ -83,21 +83,23 @@ class ABCV6ModelWriter(object):
             for lod in piece.lods:
                 buffer.extend(struct.pack('I', model.face_count))
                 for face in lod.faces:
-                    buffer.extend(struct.pack('2f', face.vertices[0].texcoord.x, face.vertices[0].texcoord.y))
-                    buffer.extend(struct.pack('2f', face.vertices[1].texcoord.x, face.vertices[1].texcoord.y))
+                    # face.vertices[0], face.vertices[2] = face.vertices[2], face.vertices[0]
                     buffer.extend(struct.pack('2f', face.vertices[2].texcoord.x, face.vertices[2].texcoord.y))
-                    buffer.extend(struct.pack('3H', face.vertices[0].vertex_index, face.vertices[1].vertex_index, face.vertices[2].vertex_index))
+                    buffer.extend(struct.pack('2f', face.vertices[1].texcoord.x, face.vertices[1].texcoord.y))
+                    buffer.extend(struct.pack('2f', face.vertices[0].texcoord.x, face.vertices[0].texcoord.y))
+                    buffer.extend(struct.pack('3H', face.vertices[2].vertex_index, face.vertices[1].vertex_index, face.vertices[0].vertex_index))
                     normal = face.normal.normalized() * 127
-                    buffer.extend(struct.pack('3b', int(normal.x), int(-normal.y), int(normal.z)))
+                    buffer.extend(struct.pack('3b', int(normal.x), int(normal.y), int(normal.z)))
 
                 buffer.extend(struct.pack('I', model.vertex_count))
                 buffer.extend(struct.pack('I', len(lod.vertices))) # lod[0].vert_count
                 for vertex in lod.vertices:
                     buffer.extend(self._vector_to_bytes(vertex.weights[0].location))
                     normal = vertex.normal.normalized() * 127
-                    buffer.extend(struct.pack('3b', int(normal.x), int(-normal.y), int(normal.z)))
+                    buffer.extend(struct.pack('3b', int(normal.x), int(normal.y), int(normal.z)))
                     buffer.extend(struct.pack('B', vertex.weights[0].node_index)) # TODO: error out on more than a single weight?
                     buffer.extend(struct.pack('2H', 0, 0)) # TODO: lod related, I think?
+                    print("Written normal:", int(normal.x), int(normal.y), int(normal.z)) # normals debug
 
         sections.append(Section('Geometry', bytes(buffer)))
 


### PR DESCRIPTION
-changed "time" to be explicit int in builder.py (4.1+ compat)
-changed reading/writing normals to closer match the original vertex normal data of the abc
-"mesh.normals_split_custom_set_from_vertices(custom_normals)" used to set custom normals since attribute normal from MeshLoop is read-only in 4.1+
-vertex_normals.py helper function added, one-click solution to generate model normals with the same logic as ModelEdit.exe